### PR TITLE
Fix the bored-sleep cycle timers

### DIFF
--- a/src/behavior-cfg.scm
+++ b/src/behavior-cfg.scm
@@ -104,10 +104,15 @@
 (emo-gest-spec "chat-neg-think" "noop"                 0.2 0   0   1 1 0   0  )
 
 ; --------------------------------------------------------
-; Dice-roll.  Perform some action some fraction of the time.
+; Dice-roll.  Probability of performing some action as the result of
+;    some event.
 
+; Probability of looking at someone who entered the room.
 (dice-roll "glance new face"   0.5) ; line 590 -- glance_probability_for_new_faces
+
+; Probability of looking at spot where someone was last seen.
 (dice-roll "glance lost face"  0.5) ; -- glance_probability_for_lost_faces
+
 (dice-roll "group interaction" 0.7) ; line 599 -- glance_probability
 (dice-roll "go to sleep"       0.1) ; line 699 -- sleep_probability
 (dice-roll "wake up"           0.5) ; line 619 -- wake_up_probability
@@ -125,8 +130,11 @@
 
 ; Wake up after 25 seconds ...
 (State (Schema "time_to_wake_up") (Number 25))
+
 ; After 25 seconds of boredom, maybe fall asleep.
-(State (Schema "time_bored_to_sleep") (Number 25))
+; Fall asleep for sure after 125 seconds.
+(State (Schema "time_to_sleep_min") (Number 25))
+(State (Schema "time_to_sleep_max") (Number 125))
 
 ; line 4 default_emotion_duration is 1 second but that's nuts.
 (State (Schema "default_emotion_duration") (Number 6.0))

--- a/src/behavior-cfg.scm
+++ b/src/behavior-cfg.scm
@@ -114,8 +114,6 @@
 (dice-roll "glance lost face"  0.5) ; -- glance_probability_for_lost_faces
 
 (dice-roll "group interaction" 0.7) ; line 599 -- glance_probability
-(dice-roll "go to sleep"       0.1) ; line 699 -- sleep_probability
-(dice-roll "wake up"           0.5) ; line 619 -- wake_up_probability
 
 ; --------------------------------------------------------
 ; Time-related conf paramters
@@ -128,13 +126,14 @@
 (State (Schema "time_to_make_gesture_min") (Number 6))
 (State (Schema "time_to_make_gesture_max") (Number 10))
 
-; Wake up after 25 seconds ...
-(State (Schema "time_to_wake_up") (Number 25))
+; Sleep at least 25 seconds ... at most 160
+(State (Schema "time_sleeping_min") (Number 25))
+(State (Schema "time_sleeping_max") (Number 160))
 
 ; After 25 seconds of boredom, maybe fall asleep.
 ; Fall asleep for sure after 125 seconds.
-(State (Schema "time_to_sleep_min") (Number 25))
-(State (Schema "time_to_sleep_max") (Number 125))
+(State (Schema "time_boredom_min") (Number 25))
+(State (Schema "time_boredom_max") (Number 125))
 
 ; line 4 default_emotion_duration is 1 second but that's nuts.
 (State (Schema "default_emotion_duration") (Number 6.0))

--- a/src/behavior-cfg.scm
+++ b/src/behavior-cfg.scm
@@ -125,6 +125,8 @@
 
 ; Wake up after 25 seconds ...
 (State (Schema "time_to_wake_up") (Number 25))
+; After 25 seconds of boredom, maybe fall asleep.
+(State (Schema "time_bored_to_sleep") (Number 25))
 
 ; line 4 default_emotion_duration is 1 second but that's nuts.
 (State (Schema "default_emotion_duration") (Number 6.0))

--- a/src/behavior-cfg.scm
+++ b/src/behavior-cfg.scm
@@ -24,6 +24,7 @@
 ; Translation of behavior.cfg line 9 ff
 (emo-expr-spec "new-arrival" "surprised"  1.0 0.2 0.4 10 15)
 
+; Used when chatbot is not happy; also, when someone leaves.
 (emo-expr-spec "frustrated" "confused"    0.4 0.4 0.6 3 7)
 (emo-expr-spec "frustrated" "recoil"      0.3 0.4 0.6 3 7)
 (emo-expr-spec "frustrated" "surprised"   0.3 0.1 0.2 3 7)
@@ -42,6 +43,7 @@
 (emo-expr-spec "wake-up"  "happy"         0.2  0.5 0.7 5 15)
 (emo-expr-spec "wake-up"  "irritated"     0.6  0.1 0.4 1  4)
 
+; Used when chatbot is happy
 (emo-expr-spec "neutral-speech"  "happy"         0.2  0.1 0.3 4 8)
 (emo-expr-spec "neutral-speech"  "comprehending" 0.4  0.5 0.8 4 8)
 (emo-expr-spec "neutral-speech"  "engaged"       0.4  0.5 0.8 4 8)

--- a/src/btree.scm
+++ b/src/btree.scm
@@ -228,14 +228,20 @@
 							(Get (State (Schema prev-ts) (Variable "$p"))))))
 				; Update time of last check to now.
 				(True (Put (State (Schema prev-ts) (Variable "$x")) (Time)))
+
+				; Perform a pro-rated coin flip. If it is only a very short
+				; time since we were last called, it is very unlikely that
+				; well the random number will come up heads.  But if its
+				; been a long time, then very likely the coin will come up
+				; heads.
 				(GreaterThan
+					(Get (State (Schema delta-ts) (Variable "$delta")))
 					; Random number in the configured range.
 					(RandomNumber
 						(Number 0)
 						(Minus
 							(Get (State (Schema max-name) (Variable "$max")))
 							(Get (State (Schema min-name) (Variable "$min")))))
-					(Get (State (Schema delta-ts) (Variable "$delta")))
 				)
 			)
 	)))

--- a/src/btree.scm
+++ b/src/btree.scm
@@ -272,7 +272,7 @@
 	"time_to_make_gesture_min" "time_to_make_gesture_max")
 
 ; --------------------------------------------------------
-; temp scaffolding and junk.
+; Some debug prints.
 
 (define (print-msg node) (display (cog-name node)) (newline) (stv 1 1))
 (define (print-atom atom) (format #t "~a\n" atom) (stv 1 1))
@@ -284,6 +284,14 @@
 	(display (cog-name (car (cog-outgoing-set (cog-execute!
 			(DefinedSchemaNode "Current interaction target"))))))
 	(newline)
+	(stv 1 1))
+
+; Print message, then print elapsed time
+(define (print-msg-time node time)
+	(display (cog-name node))
+	(display " Elapsed: ")
+	(display (cog-name time))
+	(display " seconds\n")
 	(stv 1 1))
 
 ; --------------------------------------------------------
@@ -985,8 +993,9 @@
 (DefineLink
 	(DefinedPredicateNode "Go to sleep")
 	(SequentialAndLink
-		(EvaluationLink (GroundedPredicateNode "scm: print-msg")
-			(ListLink (Node "--- Go to sleep.")))
+		(EvaluationLink (GroundedPredicateNode "scm: print-msg-time")
+			(ListLink (Node "--- Go to sleep.")
+				(Minus (Time) (DefinedSchema "get bored timestamp"))))
 		(TrueLink (DefinedSchemaNode "set sleep timestamp"))
 		(PutLink (DefinedPredicateNode "Show random expression")
 			(ConceptNode "sleep"))

--- a/src/btree.scm
+++ b/src/btree.scm
@@ -65,6 +65,7 @@
 (define soma-state (AnchorNode "Soma State"))
 (define soma-sleeping (ConceptNode "Sleeping"))
 (define soma-awake (ConceptNode "Awake"))
+(define soma-bored (ConceptNode "Bored"))
 
 ;; Assume Eva is sleeping at first
 (StateLink soma-state soma-sleeping)
@@ -975,14 +976,27 @@
 ;; Go to sleep after a while, and wake up every now and then.
 ;; line 507 -- nothing_is_happening()
 (DefineLink
-	(DefinedPredicateNode "Nothing is happening")
-	(SequentialAndLink  ; line 508
-		(SequentialOrLink  ; line 509
+	(DefinedPredicate "Nothing is happening")
+	(SequentialAnd  ; line 508
+
+		; If we are not bored already, we are bored now...
+		(SequentialOr
+			(Not (Equal (SetLink soma-bored)
+				(Get (State soma-state (Variable "$x")))))
+
+			; ... print output.
+			(False (Evaluation (GroundedPredicate "scm: print-msg")
+				(ListLink (Node "--- Bored! nothing is happening!"))))
+
+			(True (DefinedSchema "set bored timestamp"))
+		)
+
+		(SequentialOr  ; line 509
 			; ##### Is Not Sleeping #####
-			(SequentialAndLink ; line 511
-				(NotLink (EqualLink
-					(SetLink soma-sleeping)
-					(GetLink (StateLink soma-state (VariableNode "$x")))))
+			(SequentialAnd ; line 511
+				; Proceed only if not sleeping ...
+				(Not (Equal (SetLink soma-sleeping)
+					(Get (State soma-state (Variable "$x")))))
 
 				(SequentialOrLink  ; line 513
 					; ##### Go To Sleep #####

--- a/src/btree.scm
+++ b/src/btree.scm
@@ -1023,9 +1023,13 @@
 	(DefinedPredicate "Nothing is happening")
 	(SequentialAnd  ; line 508
 
-		; If we are not bored already, we are bored now...
+		; If we are not bored already, and we are not sleeping,
+		; then we are bored now...
 		(SequentialOr
 			(Equal (SetLink soma-bored)
+				(Get (State soma-state (Variable "$x"))))
+
+			(Equal (SetLink soma-sleeping)
 				(Get (State soma-state (Variable "$x"))))
 
 			(SequentialAnd

--- a/src/btree.scm
+++ b/src/btree.scm
@@ -208,10 +208,16 @@
 	"time_to_change_face_target_min" "time_to_change_face_target_max")
 
 ; Return true if we've been sleeping for long enough (i.e. longer than
-; the time_to_wake_up parameter.)
+; the time_to_wake_up parameter).
 ; line 707 -- is_time_to_wake_up()
 (change-template "Time to wake up" "sleep"
 	"time_to_wake_up" "time_to_wake_up")
+
+; Return true if we've been bored for a long time (i.e. longer than
+; the time_bored_to_sleep parameter).
+; line 611 -- bored_since, sleep probability.
+(change-template "Bored too long" "bored"
+	"time_bored_to_sleep" "time_bored_to_sleep")
 
 ;; Evaluate to true, if an expression should be shown.
 ;; line 933, should_show_expression()
@@ -998,28 +1004,28 @@
 				(Not (Equal (SetLink soma-sleeping)
 					(Get (State soma-state (Variable "$x")))))
 
-				(SequentialOrLink  ; line 513
+				(SequentialOr  ; line 513
 					; ##### Go To Sleep #####
-					(SequentialAndLink  ; line 515
-;; XXX incomplete, should depend on "bored-since" time
-;; if bored for 5 minutes, go to sleep.
-						(DefinedPredicateNode "dice-roll: go to sleep")
-						(DefinedPredicateNode "Go to sleep"))
+					(SequentialAnd  ; line 515
+						(DefinedPredicate "Bored too long")
+						(DefinedPredicate "dice-roll: go to sleep")
+						(DefinedPredicate "Go to sleep"))
+
 					; ##### Search For Attention #####
 					; If we didn't fall asleep above, then search for attention.
-					(DefinedPredicateNode "Search for attention")
+					(DefinedPredicate "Search for attention")
 				))
 			; ##### Is Sleeping #####
-			(SequentialOrLink  ; line 528
+			(SequentialOr  ; line 528
 				; ##### Wake Up #####
-				(SequentialAndLink  ; line 530
-					(DefinedPredicateNode "dice-roll: wake up")
+				(SequentialAnd  ; line 530
+					(DefinedPredicate "dice-roll: wake up")
 					; did we sleep for long enough?
-					(DefinedPredicateNode "Time to wake up")
-					(DefinedPredicateNode "Wake up")
+					(DefinedPredicate "Time to wake up")
+					(DefinedPredicate "Wake up")
 				)
 				; ##### Continue To Sleep #####
-				(DefinedPredicateNode "Continue sleeping")
+				(DefinedPredicate "Continue sleeping")
 			)
 		)
 

--- a/src/btree.scm
+++ b/src/btree.scm
@@ -215,20 +215,22 @@
 				(Get (State (Schema max-name) (Variable "$max")))
 			)
 			(SequentialAnd
+				; Delta is the time since the last check.
+				(True (Put (State (Schema delta-ts) (Variable "$x"))
+						(Minus (Time)
+							(Get (State (Schema prev-ts) (Variable "$p"))))))
+				; Update time of last check to now. Must record this
+				; timestamp before the min-time rejection, below.
+				(True (Put (State (Schema prev-ts) (Variable "$x")) (Time)))
+
 				; If elapsed time less than min, then false.
 				(GreaterThan
 					; Minus computes number of seconds since interaction start.
 					(Minus (Time) (DefinedSchema get-ts))
 					(Get (State (Schema min-name) (Variable "$min")))
 				)
-				; Compute integral: how long since last check?
-				; Delta is the time since the last check.
-				(True (Put (State (Schema delta-ts) (Variable "$x"))
-						(Minus (Time)
-							(Get (State (Schema prev-ts) (Variable "$p"))))))
-				; Update time of last check to now.
-				(True (Put (State (Schema prev-ts) (Variable "$x")) (Time)))
 
+				; Compute integral: how long since last check?
 				; Perform a pro-rated coin flip. If it is only a very short
 				; time since we were last called, it is very unlikely that
 				; well the random number will come up heads.  But if its

--- a/src/btree.scm
+++ b/src/btree.scm
@@ -987,15 +987,19 @@
 
 		; If we are not bored already, we are bored now...
 		(SequentialOr
-			(Not (Equal (SetLink soma-bored)
-				(Get (State soma-state (Variable "$x")))))
+			(Equal (SetLink soma-bored)
+				(Get (State soma-state (Variable "$x"))))
 
-			; ... print output.
-			(False (Evaluation (GroundedPredicate "scm: print-msg")
-				(ListLink (Node "--- Bored! nothing is happening!"))))
+			(SequentialAnd
+				(True (Put (State soma-state (Variable "$x"))
+					(SetLink soma-bored)))
 
-			(True (DefinedSchema "set bored timestamp"))
-		)
+				(True (DefinedSchema "set bored timestamp"))
+
+				; ... print output.
+				(Evaluation (GroundedPredicate "scm: print-msg")
+					(ListLink (Node "--- Bored! nothing is happening!")))
+			))
 
 		(SequentialOr  ; line 509
 			; ##### Is Not Sleeping #####

--- a/src/btree.scm
+++ b/src/btree.scm
@@ -217,14 +217,15 @@
 			(SequentialAnd
 				; If elapsed time less than min, then false.
 				(GreaterThan
-					(Get (State (Schema min-name) (Variable "$min")))
 					; Minus computes number of seconds since interaction start.
 					(Minus (Time) (DefinedSchema get-ts))
+					(Get (State (Schema min-name) (Variable "$min")))
 				)
 				; Compute integral: how long since last check?
 				; Delta is the time since the last check.
 				(True (Put (State (Schema delta-ts) (Variable "$x"))
-						(Minus (Time) (Get (State (Schema prev-ts))))))
+						(Minus (Time)
+							(Get (State (Schema prev-ts) (Variable "$p"))))))
 				; Update time of last check to now.
 				(True (Put (State (Schema prev-ts) (Variable "$x")) (Time)))
 				(GreaterThan

--- a/src/btree.scm
+++ b/src/btree.scm
@@ -257,13 +257,13 @@
 ; the time_to_wake_up parameter).
 ; line 707 -- is_time_to_wake_up()
 (change-template "Time to wake up" "sleep"
-	"time_to_wake_up" "time_to_wake_up")
+	"time_sleeping_min" "time_sleeping_max")
 
 ; Return true if we've been bored for a long time (i.e. longer than
 ; the time_bored_to_sleep parameter).
 ; line 611 -- bored_since, sleep probability.
 (change-template "Bored too long" "bored"
-	"time_to_sleep_min" "time_to_sleep_max")
+	"time_boredom_min" "time_boredom_max")
 
 ;; Evaluate to true, if an expression should be shown.
 ;; line 933, should_show_expression()
@@ -1021,8 +1021,9 @@
 (DefineLink
 	(DefinedPredicateNode "Wake up")
 	(SequentialAndLink
-		(EvaluationLink (GroundedPredicateNode "scm: print-msg")
-			(ListLink (Node "--- Wake up!")))
+		(EvaluationLink (GroundedPredicateNode "scm: print-msg-time")
+			(ListLink (Node "--- Wake up!")
+				(Minus (Time) (DefinedSchema "get sleep timestamp"))))
 		(TrueLink (DefinedSchemaNode "set bored timestamp"))
 		(TrueLink (PutLink (StateLink soma-state (VariableNode "$x"))
 			soma-awake))
@@ -1081,8 +1082,7 @@
 			(SequentialOr  ; line 528
 				; ##### Wake Up #####
 				(SequentialAnd  ; line 530
-					(DefinedPredicate "dice-roll: wake up")
-					; did we sleep for long enough?
+					; Did we sleep for long enough?
 					(DefinedPredicate "Time to wake up")
 					(DefinedPredicate "Wake up")
 				)


### PR DESCRIPTION
The sleep/wake timers were implemented incorrectly; They worked OK as long as the 
main loop did not run very often, but were broken by the high update rate.  
Re-implement so that they are independent of the main-loop cycle time.
