### PR TITLE
More-or-less working verbal look-at

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -173,4 +173,6 @@ A list of random ideas.
 * "Search for attention" is a state, need to record that in a state
   variable. Ditto for "Interact with people"
 
-  (DefinedPredicateNode "is interacting with someone?")
+  (DefinedPredicateNode "Is interacting with someone?")
+
+  Everythig emitted to ROS is a state.... look for teh behavior pubs.

--- a/src/behavior.scm
+++ b/src/behavior.scm
@@ -329,7 +329,9 @@
 						(False)
 					)
 					(True))
-			))
+			)
+			(DefinedPredicate "Is interacting with someone?")
+		)
 	))
 
 ; ------------------------------------------------------

--- a/src/behavior.scm
+++ b/src/behavior.scm
@@ -111,7 +111,7 @@
 	(DefinedPredicate "Interact with face")
 	(SequentialAnd
 		;; Look at the interaction face
-		(True (DefinedSchema "look at person"))
+		(DefinedPredicate "look at person")
 
 		;; Show random expressions only if NOT talking
 		(SequentialOr
@@ -144,7 +144,7 @@
 			(ListLink bhv-source (Concept "new-arrival")))
 
 		(DefinedPredicate "interact with new person")
-		(True (DefinedSchema "look at person"))
+		(DefinedPredicate "look at person")
 		(Put (DefinedPredicate "Show random expression")
 			(ConceptNode "new-arrival"))
 		(Put (DefinedPredicate "Publish behavior")
@@ -162,7 +162,7 @@
 		(True (DefinedPredicate "If sleeping then wake"))
 		(True (DefinedPredicate "If bored then alert"))
 		(DefinedPredicate "interact with requested person")
-		(True (DefinedSchema "look at person"))
+		(DefinedPredicate "look at person")
 		(Put (DefinedPredicate "Publish behavior")
 			(Concept "Look at requested face"))
 		(Evaluation (GroundedPredicate "scm: print-msg-face")

--- a/src/behavior.scm
+++ b/src/behavior.scm
@@ -175,7 +175,7 @@
 (DefineLink
 	(DefinedPredicate "Interacting Sequence")
 	(SequentialAnd
-		(DefinedPredicate "is interacting with someone?")
+		(DefinedPredicate "Is interacting with someone?")
 		(DefinedPredicate "dice-roll: glance new face")
 		(True (DefinedSchema "glance at new person"))
 		(Evaluation (GroundedPredicate "scm: print-msg")
@@ -250,7 +250,7 @@
 			;; Were we interacting with someone else?  If so, then
 			;; maybe glance at the location of the person who left.
 			(SequentialAnd
-				(DefinedPredicate "is interacting with someone?")
+				(DefinedPredicate "Is interacting with someone?")
 				(SequentialOr
 					(NotLink (DefinedPredicate "dice-roll: glance lost face"))
 					(FalseLink (DefinedSchema "glance at lost face"))
@@ -297,7 +297,7 @@
 			; someone for too long.
 			(SequentialAnd
 				(SequentialOr
-					(Not (DefinedPredicate "is interacting with someone?"))
+					(Not (DefinedPredicate "Is interacting with someone?"))
 					(SequentialAnd
 						(DefinedPredicate "More than one face visible")
 						(DefinedPredicate "Time to change interaction")))

--- a/src/faces.scm
+++ b/src/faces.scm
@@ -79,8 +79,8 @@
 
 
 (define (show-eye-contact-state)
-	(define e-c-state (AnchorNode "Eye Contact State"))
-	(car (cog-chase-link 'StateLink 'ConceptNode e-c-state)))
+	(define e-c-state (Anchor "Eye Contact State"))
+	(car (cog-chase-link 'StateLink 'NumberNode e-c-state)))
 
 
 ; define-public because `unit-test.scm` uses it.

--- a/src/orchestrate.scm
+++ b/src/orchestrate.scm
@@ -124,6 +124,34 @@
 		)))
 
 ; -------------------------------------------------------------
+; As above, but (momentarily) break eye contact, first.
+; Otherwise, the behavior tree forces eye contact to be continueally
+; running, and the turn-look command is promptly over-ridden.
+; XXX FIXME, this is still broken during search for attention.
+
+(DefineLink
+	(DefinedPredicate "Look command")
+	(LambdaLink
+		(VariableList (Variable "$x") (Variable "$y") (Variable "$z"))
+		(SequentialAndLink
+			(DefinedPredicate "break eye contact")
+			(EvaluationLink (DefinedPredicate "Gaze at point")
+				(ListLink (Variable "$x") (Variable "$y") (Variable "$z")))
+			(EvaluationLink (DefinedPredicate "Look at point")
+				(ListLink (Variable "$x") (Variable "$y") (Variable "$z")))
+		)))
+
+(DefineLink
+	(DefinedPredicate "Gaze command")
+	(LambdaLink
+		(VariableList (Variable "$x") (Variable "$y") (Variable "$z"))
+		(SequentialAndLink
+			(DefinedPredicate "break eye contact")
+			(EvaluationLink (DefinedPredicate "Gaze at point")
+				(ListLink (Variable "$x") (Variable "$y") (Variable "$z")))
+		)))
+
+; -------------------------------------------------------------
 ; Publish the current behavior.
 ; Cheap hack to allow external ROS nodes to know what we are doing.
 ; The string name of the node is sent directly as a ROS String message

--- a/src/self-model.scm
+++ b/src/self-model.scm
@@ -439,9 +439,9 @@
 ;; Return true if interacting with someone.
 ;; This is a compound predicate: we are interacting if the interaction
 ;; state is set, or if the TTS system/chatbot is still vocalizing.
-;; (cog-evaluate! (DefinedPredicateNode "is interacting with someone?"))
+;; (cog-evaluate! (DefinedPredicateNode "Is interacting with someone?"))
 (DefineLink
-	(DefinedPredicate "is interacting with someone?")
+	(DefinedPredicate "Is interacting with someone?")
 	(OrLink
 		; true if talking not listening.
 		(NotLink (DefinedPredicate "chatbot is listening"))
@@ -535,14 +535,14 @@
 ;; actually cause the robot to look at them.  Use the schema
 ;; (DefinedSchema "look at person") to make it look.
 (DefineLink
-	(DefinedPredicateNode "Change interaction")
-	(SequentialAndLink
+	(DefinedPredicate "Change interaction")
+	(SequentialAnd
 		; First, pick a face at random...
-		(TrueLink (PutLink
+		(True (Put
 			(StateLink eye-contact-state (VariableNode "$face-id"))
-			(DefinedSchemaNode "Select random face")))
+			(DefinedSchema "Select random face")))
 		; Record a timestamp
-		(TrueLink (DefinedSchemaNode "set interaction timestamp"))
+		(True (DefinedSchema "set interaction timestamp"))
 		; Diagnostic print
 		(Evaluation (GroundedPredicate "scm: print-msg-face")
 			(ListLink (Node "--- Start new interaction")))

--- a/src/self-model.scm
+++ b/src/self-model.scm
@@ -474,12 +474,12 @@
 ;; Move to a neutral head position. Right now, this just issues a
 ;; look-at command; it could do more (e.g. halt the chatbot.)
 (DefineLink
-	(DefinedPredicateNode "return to neutral")
-	(SequentialAndLink
-		(EvaluationLink (GroundedPredicateNode "py:look_at_face")
+	(DefinedPredicate "return to neutral")
+	(SequentialAnd
+		(Evaluation (GroundedPredicate "py:look_at_face")
 			(ListLink neutral-face))
-		(TrueLink (PutLink
-			(StateLink eye-contact-state (VariableNode "$face-id"))
+		(True (Put
+			(State eye-contact-state (Variable "$face-id"))
 			no-interaction))
 	))
 

--- a/src/self-model.scm
+++ b/src/self-model.scm
@@ -77,6 +77,9 @@
 ; -----------
 ;; The eye-contact-state will be linked to the face-id of
 ;; person with whom we are making eye-contact with.
+;; This is usually the same as the interaction-state, but not always:
+;; If told to look away, she will break eye-contact but not break
+;; interaction.
 (define-public eye-contact-state (AnchorNode "Eye Contact State"))
 (define-public no-interaction (ConceptNode "none"))
 
@@ -475,6 +478,20 @@
 			(ListLink (Variable "$face")))
 		(Get (State eye-contact-state (Variable "$x")))
 	))
+
+;; Break eye contact; this does not change the interaction state.
+(DefineLink
+	(DefinedPredicate "break eye contact")
+	(True (Put (State eye-contact-state (Variable "$face-id"))
+		no-interaction))
+)
+
+;; Make eye-contact with the interaction target.
+(DefineLink
+	(DefinedPredicate "make eye contact")
+	(True (Put (State eye-contact-state (Variable "$face-id"))
+		(Get (State interaction-state (Variable "$x"))) ))
+)
 
 ;; Move to a neutral head position.
 ;; This clears the interaction and eye-contact state,

--- a/src/self-model.scm
+++ b/src/self-model.scm
@@ -480,10 +480,10 @@
 		(NotLink (Equal
 			(Get (State eye-contact-state (Variable "$x")))
 			(SetLink no-interaction)))
-		(Put
+		(True (Put
 			(Evaluation (GroundedPredicate "py:look_at_face")
 				(ListLink (Variable "$face")))
-			(Get (State eye-contact-state (Variable "$x"))))
+			(Get (State eye-contact-state (Variable "$x")))))
 	))
 
 ;; Break eye contact; this does not change the interaction state.

--- a/src/self-model.scm
+++ b/src/self-model.scm
@@ -95,7 +95,7 @@
 (StateLink request-eye-contact-state no-interaction)
 
 ;; The "look at neutral position" face. Used to tell the eye/head
-;; movemet subsystem to move to a neutral position.
+;; movement subsystem to move to a neutral position.
 (define neutral-face (ConceptNode "0"))
 
 ;; The person she is interacting with.
@@ -315,8 +315,8 @@
 
 ;; Return the person with whom we are currently interacting.
 (DefineLink
-	(DefinedSchemaNode "Current interaction target")
-	(GetLink (StateLink interaction-state (VariableNode "$x"))))
+	(DefinedSchema "Current interaction target")
+	(Get (State interaction-state (Variable "$x"))))
 
 ;; Return true if some face has is no longer visible (has left the room)
 ;; We detect this by looking for "acked" faces tat are not also visible.
@@ -470,13 +470,20 @@
 	))
 
 
-;; Send ROS message to look at the person we are interacting with.
+;; Send ROS message to actually make eye-contact with the person
+;; we should be making eye-contact with.
 (DefineLink
-	(DefinedSchema "look at person")
-	(Put
-		(Evaluation (GroundedPredicate "py:look_at_face")
-			(ListLink (Variable "$face")))
-		(Get (State eye-contact-state (Variable "$x")))
+	(DefinedPredicate "look at person")
+	(SequentialAnd
+		;; Issue the look-at command, only if there is someone to
+		;; make eye conact with.
+		(NotLink (Equal
+			(Get (State eye-contact-state (Variable "$x")))
+			(SetLink no-interaction)))
+		(Put
+			(Evaluation (GroundedPredicate "py:look_at_face")
+				(ListLink (Variable "$face")))
+			(Get (State eye-contact-state (Variable "$x"))))
 	))
 
 ;; Break eye contact; this does not change the interaction state.


### PR DESCRIPTION
Sufficient hackery to make the verbal look-at commands work.

Its imperfect -- if the face detector sees a new face, the look-at direction is broken off, and she looks at the new person, instead.  This is expected/adequeate for just right now, but needs better control in the long run.
