### PR TITLE
Fix behavior switches problem when running btree-psi

### DIFF
--- a/src/put_atoms.py
+++ b/src/put_atoms.py
@@ -87,7 +87,7 @@ class PutAtoms:
 
 	# Start or stop the behavior tree.
 	def btree_stop(self):
-		scheme_eval(self.atomspace, "(behavior-tree-halt)")
+		scheme_eval(self.atomspace, "(halt)")
 
 	def btree_run(self):
-		scheme_eval(self.atomspace, "(behavior-tree-run)")
+		scheme_eval(self.atomspace, "(run)")


### PR DESCRIPTION
Currently if we are running btree-psi, it can't be switched off from the web interface (with an unbounded variable `(behavior-tree-halt)` error), this should fix the problem
