### PR TITLE
Add types to GetLinks and PresentLink-predicates

### DIFF
--- a/src/behavior.scm
+++ b/src/behavior.scm
@@ -295,7 +295,9 @@
 			(SequentialAnd
 				(Equal
 					(DefinedSchema "New departures")
-					(Get (State eye-contact-state (Variable "$x"))))
+					(Get
+						(TypedVariable (Variable "$x") (Type "NumberNode"))
+						(State eye-contact-state (Variable "$x"))))
 				(DefinedPredicate "Show frustrated expression")
 				(DefinedPredicate "return to neutral")
 			)

--- a/src/cfg-tools.scm
+++ b/src/cfg-tools.scm
@@ -84,7 +84,9 @@
 	(DefineLink
 		(DefinedPredicateNode (string-append "dice-roll: " action))
 		(GreaterThan
-			(Get (State (Schema prob-name) (Variable "$x")))
+			(Get
+				(TypedVariable (Variable "$x") (Type "NumberNode"))
+				(State (Schema prob-name) (Variable "$x")))
 			(RandomNumber (Number 0) (Number 1)))))
 
 ; --------------------------------------------------------

--- a/src/express.scm
+++ b/src/express.scm
@@ -32,7 +32,9 @@
 		(RandomChoice
 			(GetLink
 				; Return a bunch of probability-expr pairs.
-				(VariableList (Variable "$prob") (Variable "$expr"))
+				(VariableList
+					(TypedVariable (Variable "$prob") (Type "NumberNode"))
+					(TypedVariable (Variable "$expr") (Type "ConceptNode")))
 				(AndLink
 					(Evaluation
 						(Predicate "Emotion-expression")
@@ -52,7 +54,9 @@
 		(Variable "$emo")
 		(RandomChoice
 			(GetLink
-				(VariableList (Variable "$prob") (Variable "$expr"))
+				(VariableList
+					(TypedVariable (Variable "$prob") (Type "NumberNode"))
+					(TypedVariable (Variable "$expr") (Type "ConceptNode")))
 				(AndLink
 					(Evaluation
 						(Predicate "Emotion-gesture")
@@ -72,11 +76,13 @@
 	(LambdaLink
 		(VariableList (VariableNode "$emo") (VariableNode "$expr"))
 		(RandomNumberLink
-			(GetLink (VariableNode "$int-min")
+			(GetLink
+				(TypedVariable (Variable "$int-min") (Type "NumberNode"))
 				(StateLink (ListLink
 					(VariableNode "$emo") (VariableNode "$expr")
 					(SchemaNode min-name)) (VariableNode "$int-min")))
-			(GetLink (VariableNode "$int-max")
+			(GetLink
+				(TypedVariable (Variable "$int-max") (Type "NumberNode"))
 				(StateLink (ListLink
 					(VariableNode "$emo") (VariableNode "$expr")
 					(SchemaNode max-name)) (VariableNode "$int-max")))

--- a/src/face-priority.scm
+++ b/src/face-priority.scm
@@ -56,7 +56,9 @@
             (Variable "filter-face-id")
             (Type "NumberNode"))
         (Get
-            (VariableList (Variable "face-id") (Variable "priority"))
+            (VariableList
+                (TypedVariable (Variable "face-id") (Type "NumberNode"))
+                (TypedVariable (Variable "priority") (Type "NumberNode")))
             (And
                 (Identical (Variable "filter-face-id") (Variable "face-id"))
                 (State
@@ -99,7 +101,9 @@
                         (Variable "face-id"))
                     (Variable "priority")))
             (Get
-                (VariableList (Variable "face-id") (Variable "priority"))
+                (VariableList
+                    (TypedVariable (Variable "face-id") (Type "NumberNode"))
+                    (TypedVariable (Variable "priority") (Type "NumberNode")))
                 (And
                     (Identical (Variable "del-face-id") (Variable "face-id"))
                     (State
@@ -229,7 +233,9 @@
             (Variable "filter-face-id")
             (Type "NumberNode"))
         (Get
-            (VariableList (Variable "face-id") (Variable "priority"))
+            (VariableList
+                (TypedVariable (Variable "face-id") (Type "NumberNode"))
+                (TypedVariable (Variable "priority") (Type "NumberNode")))
             (And
                 (Identical (Variable "filter-face-id") (Variable "face-id"))
                 (State
@@ -265,7 +271,9 @@
             ; The GetLink is structuraly the same as
             ; (DefinedSchema "Get face priority")
             (Get
-                (VariableList (Variable "face-id") (Variable "priority"))
+                (VariableList
+                    (TypedVariable (Variable "face-id") (Type "NumberNode"))
+                    (TypedVariable (Variable "priority") (Type "NumberNode")))
                 (And
                     (Identical (Variable "del-face-id") (Variable "face-id"))
                     (State
@@ -379,13 +387,15 @@
     (DefinedPredicate "Has person being intracted with changed?")
     (SequentialOr
         (Not (Equal
-            (GetLink (State prev-interaction-state (Variable "value")))
+            (GetLink
+                (TypedVariable (Variable "value") (Type "NumberNode"))
+                (State prev-interaction-state (Variable "value")))
             (DefinedSchema "Current interaction target")))
     ))
 
 (Define
     (DefinedSchema "Set previous interaction value")
     (Lambda
-        (Variable "value")
+        (TypedVariable (Variable "value") (Type "NumberNode"))
         (State prev-interaction-state (Variable "value"))
     ))

--- a/src/primitives.scm
+++ b/src/primitives.scm
@@ -111,13 +111,18 @@ except:
 			(GreaterThan
 				; Minus computes number of seconds since interaction start.
 				(Minus (TimeLink) (DefinedSchema get-ts))
-				(Get (State (Schema max-name) (Variable "$max")))
+				(Get
+					(TypedVariable (Variable "$max") (Type "NumberNode"))
+					(State (Schema max-name) (Variable "$max")))
 			)
 			(SequentialAnd
 				; Delta is the time since the last check.
 				(True (Put (State (Schema delta-ts) (Variable "$x"))
 						(Minus (TimeLink)
-							(Get (State (Schema prev-ts) (Variable "$p"))))))
+							(Get
+								(TypedVariable
+									(Variable "$p") (Type "NumberNode"))
+								(State (Schema prev-ts) (Variable "$p"))))))
 				; Update time of last check to now. Must record this
 				; timestamp before the min-time rejection, below.
 				(True (Put (State (Schema prev-ts) (Variable "$x")) (TimeLink)))
@@ -126,7 +131,9 @@ except:
 				(GreaterThan
 					; Minus computes number of seconds since interaction start.
 					(Minus (TimeLink) (DefinedSchema get-ts))
-					(Get (State (Schema min-name) (Variable "$min")))
+					(Get
+						(TypedVariable (Variable "$min") (Type "NumberNode"))
+						(State (Schema min-name) (Variable "$min")))
 				)
 
 				; Compute integral: how long since last check?
@@ -136,13 +143,22 @@ except:
 				; been a long time, then very likely the coin will come up
 				; heads.
 				(GreaterThan
-					(Get (State (Schema delta-ts) (Variable "$delta")))
+					(Get
+						(TypedVariable (Variable "$delta") (Type "NumberNode"))
+						(State
+							(Schema delta-ts) (Variable "$delta")))
 					; Random number in the configured range.
 					(RandomNumber
 						(Number 0)
 						(Minus
-							(Get (State (Schema max-name) (Variable "$max")))
-							(Get (State (Schema min-name) (Variable "$min")))))
+							(Get
+								(TypedVariable
+									(Variable "$max") (Type "NumberNode"))
+								(State (Schema max-name) (Variable "$max")))
+							(Get
+								(TypedVariable
+									(Variable "$min") (Type "NumberNode"))
+								(State (Schema min-name) (Variable "$min")))))
 				)
 			)
 	)))

--- a/src/self-model.scm
+++ b/src/self-model.scm
@@ -334,6 +334,7 @@
 (DefineLink
 	(DefinedPredicateNode "Did someone arrive?")
 	(SatisfactionLink
+		(TypedVariable (Variable "$face-id") (TypeNode "NumberNode"))
 		(AndLink
 			; If someone is visible...
 			(PresentLink (EvaluationLink (PredicateNode "visible face")

--- a/src/self-model.scm
+++ b/src/self-model.scm
@@ -66,13 +66,17 @@
 (DefineLink
 	(DefinedPredicate "Is sleeping?")
 	(Equal (SetLink soma-sleeping)
-		(Get (State soma-state (Variable "$x")))))
+		(Get
+			(TypedVariable (Variable "$x") (Type "ConceptNode"))
+			(State soma-state (Variable "$x")))))
 
 ;; True if bored, else false
 (DefineLink
 	(DefinedPredicate "Is bored?")
 	(Equal (SetLink soma-bored)
-		(Get (State soma-state (Variable "$x")))))
+		(Get
+			(TypedVariable (Variable "$x") (Type "ConceptNode"))
+			(State soma-state (Variable "$x")))))
 
 ; -----------
 ; The "emotional state" of the robot.  Corresponds to states declared
@@ -147,32 +151,44 @@
 (DefineLink
 	(DefinedPredicate "chatbot started talking?")
 	(Equal (Set chat-start)
-		(Get (State chat-state (Variable "$x")))))
+		(Get
+			(TypedVariable (Variable "$x") (Type "ConceptNode"))
+			(State chat-state (Variable "$x")))))
 
 (DefineLink
 	(DefinedPredicate "chatbot is talking?")
 	(Equal (Set chat-talk)
-		(Get (State chat-state (Variable "$x")))))
+		(Get
+			(TypedVariable (Variable "$x") (Type "ConceptNode"))
+			(State chat-state (Variable "$x")))))
 
 (DefineLink
 	(DefinedPredicate "chatbot stopped talking?")
 	(Equal (Set chat-stop)
-		(Get (State chat-state (Variable "$x")))))
+		(Get
+			(TypedVariable (Variable "$x") (Type "ConceptNode"))
+			(State chat-state (Variable "$x")))))
 
 (DefineLink
 	(DefinedPredicate "chatbot started listening?")
 	(Equal (Set chat-listen-start)
-		(Get (State chat-state (Variable "$x")))))
+		(Get
+			(TypedVariable (Variable "$x") (Type "ConceptNode"))
+			(State chat-state (Variable "$x")))))
 
 (DefineLink
 	(DefinedPredicate "chatbot is listening?")
 	(Equal (Set chat-listen)
-		(Get (State chat-state (Variable "$x")))))
+		(Get
+			(TypedVariable (Variable "$x") (Type "ConceptNode"))
+			(State chat-state (Variable "$x")))))
 
 (DefineLink
 	(DefinedPredicate "chatbot stopped listening?")
 	(Equal (Set chat-listen-stop)
-		(Get (State chat-state (Variable "$x")))))
+		(Get
+			(TypedVariable (Variable "$x") (Type "ConceptNode"))
+			(State chat-state (Variable "$x")))))
 
 ; Chat affect. Is the robot happy about what its saying?
 ; Right now, there are only two affects: happy and not happy.
@@ -190,13 +206,17 @@
 	(DefinedPredicate "chatbot is happy")
 	(Equal
 		(Set chat-happy)
-		(Get (State chat-affect (Variable "$x")))))
+		(Get
+			(TypedVariable (Variable "$x") (Type "ConceptNode"))
+			(State chat-affect (Variable "$x")))))
 
 (DefineLink
 	(DefinedPredicate "chatbot is negative")
 	(Equal
 		(Set chat-negative)
-		(Get (State chat-affect (Variable "$x")))))
+		(Get
+			(TypedVariable (Variable "$x") (Type "ConceptNode"))
+			(State chat-affect (Variable "$x")))))
 
 ; --------------------------------------------------------
 ; Speech-to-text (STT) related stuff.
@@ -235,7 +255,9 @@
 	(DefinedPredicate "Heard Something?")
 	(SequentialAnd
 		(NotLink (Equal (SetLink heard-nothing)
-			(Get (State heard-sound (Variable "$x")))))
+			(Get
+				(TypedVariable (Variable "$x") (Type "SentenceNode"))
+				(State heard-sound (Variable "$x")))))
 		(True (Put (State heard-sound (Variable "$x")) heard-nothing))
 	))
 
@@ -263,7 +285,9 @@
 	; timestamp getter
 	(DefineLink
 		(DefinedSchema (string-append "get " name " timestamp"))
-		(Get (State (Schema ts-name) (Variable "$x"))))
+		(Get
+			(TypedVariable (Variable "$x") (Type "NumberNode"))
+			(State (Schema ts-name) (Variable "$x"))))
 
 	; Additional state, used for computing integral, for probabilities.
 	; See below, in the time-to-change template.
@@ -367,7 +391,8 @@
 ;; Will return a SetLink holding zero, one or more face id's
 (DefineLink
 	(DefinedSchemaNode "New arrivals")
-	(GetLink
+	(Get
+		(TypedVariable (Variable "$face-id") (Type "NumberNode"))
 		(AndLink
 			; If someone is visible...
 			(PresentLink (EvaluationLink (PredicateNode "visible face")
@@ -380,7 +405,9 @@
 ;; Return the person with whom we are currently interacting.
 (DefineLink
 	(DefinedSchema "Current interaction target")
-	(Get (State interaction-state (Variable "$x"))))
+	(Get
+		(TypedVariable (Variable "$x") (TypeNode "NumberNode"))
+		(State interaction-state (Variable "$x"))))
 
 ;; Return true if some face has is no longer visible (has left the room)
 ;; We detect this by looking for "acked" faces tat are not also visible.
@@ -421,7 +448,9 @@
 	(DefinedPredicateNode "was room empty?")
 	(EqualLink
 		(SetLink room-empty)
-		(GetLink (StateLink room-state (VariableNode "$x")))
+		(Get
+			(TypedVariable (Variable "$x") (Type "ConceptNode"))
+			(StateLink room-state (VariableNode "$x")))
 	))
 
 ;; Is there someone present?  We check for acked faces.
@@ -481,7 +510,13 @@
 (DefineLink ; This is required because interaction states are using NumberNode
 	(DefinedSchema "Get recognized face's face id")
 	(LambdaLink
-		(VariableList (VariableNode "face-id") (VariableNode "recog-id"))
+		(VariableList
+			(TypedVariable
+				(Variable "face-id")
+				(TypeNode "ConceptNode"))
+			(TypedVariable
+				(Variable "recog-id")
+				(TypeNode "ConceptNode")))
 		(ExecutionOutputLink ;
 			(GroundedSchemaNode "scm: get-face-id")
 			(ListLink
@@ -511,8 +546,12 @@
 			(PutLink (StateLink glance-state (VariableNode "$face-id"))
 				(DefinedSchemaNode "Select random face")))
 		(EqualLink
-			(GetLink (StateLink glance-state (VariableNode "$face-id")))
-			(GetLink (StateLink eye-contact-state (VariableNode "$face-id")))
+			(Get
+				(TypedVariable (Variable "$face-id") (Type "NumberNode"))
+				(StateLink glance-state (VariableNode "$face-id")))
+			(Get
+				(TypedVariable (Variable "$face-id") (Type "NumberNode"))
+				(StateLink eye-contact-state (VariableNode "$face-id")))
 		)
 		(DefinedPredicateNode "More than one face visible")
 		(DefinedPredicateNode "Select random glance target")
@@ -532,7 +571,9 @@
 		(True (Put
 				(Evaluation (Predicate "acked face")
 						(ListLink (Variable "$face-id")))
-				(Get (State eye-contact-state (Variable "$x")))))
+				(Get
+					(TypedVariable (Variable "$x") (Type "NumberNode"))
+					(State eye-contact-state (Variable "$x")))))
 	))
 
 ;; Remove the lost faces from "acked face" (so that "acked face" accurately
@@ -559,7 +600,9 @@
 		; true if not not-making eye-contact.
 		(NotLink (Equal
 			(SetLink no-interaction)
-			(Get (State interaction-state (Variable "$x"))))
+			(Get
+				(TypedVariable (Variable "$x") (Type "NumberNode"))
+				(State interaction-state (Variable "$x"))))
 	)))
 
 
@@ -569,7 +612,9 @@
 	(DefinedPredicate "Skip Interaction?")
 	(Equal
 		(SetLink face-tracking-off)
-		(Get (State face-tracking-state (Variable "$x"))))
+		(Get
+			(TypedVariable (Variable "$x") (Type "ConceptNode"))
+			(State face-tracking-state (Variable "$x"))))
 	)
 
 ;; Return true if someone requests interaction.  This person will
@@ -578,7 +623,9 @@
 	(DefinedPredicate "Someone requests interaction?")
 	(NotLink (Equal
 		(SetLink no-interaction)
-		(Get (State request-eye-contact-state (Variable "$x"))))
+		(Get
+			(TypedVariable (Variable "$x") (Type "NumberNode"))
+			(State request-eye-contact-state (Variable "$x"))))
 	))
 
 ;; Send ROS message to actually make eye-contact with the person
@@ -591,12 +638,16 @@
 		;; Issue the look-at command, only if there is someone to
 		;; make eye contact with.
 		(NotLink (Equal
-			(Get (State eye-contact-state (Variable "$x")))
+			(Get
+				(TypedVariable (Variable "$x") (Type "NumberNode"))
+				(State eye-contact-state (Variable "$x")))
 			(SetLink no-interaction)))
 		(True (Put
 			(Evaluation (GroundedPredicate "scm:look-at-face")
 				(ListLink (Variable "$face")))
-			(Get (State eye-contact-state (Variable "$x")))))
+			(Get
+				(TypedVariable (Variable "$x") (Type "NumberNode"))
+				(State eye-contact-state (Variable "$x")))))
 	))
 
 ;; Break eye contact; this does not change the interaction state.
@@ -610,7 +661,9 @@
 (DefineLink
 	(DefinedPredicate "make eye contact")
 	(True (Put (State eye-contact-state (Variable "$face-id"))
-		(Get (State interaction-state (Variable "$x"))) ))
+		(Get
+			(TypedVariable (Variable "$x") (Type "NumberNode"))
+			(State interaction-state (Variable "$x"))) ))
 )
 
 ;; Move to a neutral head position.
@@ -651,7 +704,9 @@
 		(DefinedPredicate "Select random glance target")
 		(Put
 			(DefinedPredicate "glance and ack")
-			(Get (State glance-state (Variable "$face-id")))
+			(Get
+				(TypedVariable (Variable "$face-id") (Type "NumberNode"))
+				(State glance-state (Variable "$face-id")))
 		)
 	))
 


### PR DESCRIPTION
Most of the GetLinks might have issues as, but it is safer to type them as the StateLinks they wrap maybe used in different forms as new psi-rules are added.
