### PR TITLE
Don't run openpsi by default 

### DIFF
--- a/src/btree-psi.scm
+++ b/src/btree-psi.scm
@@ -86,7 +86,3 @@
 
 ; Silence the output.
 *unspecified*
-
-;; Actually set it running, by default.
-(all-threads)  ; print out the curent threads.
-(run)


### PR DESCRIPTION
This is required because there are two set of configuration in HEAD's wholeshow.