### PR TITLE
Two way dynamic parameter updates

### DIFF
--- a/src/atomic.py
+++ b/src/atomic.py
@@ -146,6 +146,7 @@ def ros_is_running():
 		return TruthValue(0, 1)
 	return TruthValue(1, 1)
 
+# Update dynamic paramater cache
 def update_opencog_control_parameter(name_node, value_node):
 	try:
 		name = name_node.name
@@ -154,3 +155,8 @@ def update_opencog_control_parameter(name_node, value_node):
 		return TruthValue(1, 1)
 	except:
 		return TruthValue(0, 1)
+
+# Update dynamic parameters
+def push_parameter_update():
+	evl.push_parameter_update()
+	return TruthValue(1, 1)

--- a/src/orchestrate.scm
+++ b/src/orchestrate.scm
@@ -254,6 +254,13 @@
 
 ; -------------------------------------------------------------
 ; For updating web-ui
+; NOTE: updating of parameters is divided into steps of upating the parameter
+; cache and then pushing the update, so as to simply syncing the values.
+; If one pushes a partial updated cache results in the publishing of the change
+; to /opencog_control topic thus resulting in an undesirable state in the
+; atomspace.
+
+; Update dynamic parameter cache
 (DefineLink
     (DefinedPredicate "update-opencog-control-parameter")
     (LambdaLink
@@ -271,11 +278,21 @@
                 (VariableNode "psi-rule-weight")))
     ))
 
+; Push dynamic parameter cache values
 (Define
-    (DefinedPredicate "update-web-ui")
-    (True (PutLink
-        (DefinedPredicate "update-opencog-control-parameter")
-        (DefinedSchema "psi-controlled-rule-state"))
-    ))
+	(DefinedPredicate "push-parameter-update")
+	(Evaluation
+		(GroundedPredicate "py: push_parameter_update")
+		(List))
+	)
+
+(Define
+	(DefinedPredicate "update-web-ui")
+	(SequentialAnd
+		(True (PutLink
+			(DefinedPredicate "update-opencog-control-parameter")
+			(DefinedSchema "psi-controlled-rule-state")))
+		(DefinedPredicate "push-parameter-update")
+	))
 ; -------------------------------------------------------------
 *unspecified*  ; Make the load be silent

--- a/src/orchestrate.scm
+++ b/src/orchestrate.scm
@@ -257,8 +257,8 @@
 ; NOTE: updating of parameters is divided into steps of upating the parameter
 ; cache and then pushing the update, so as to simply syncing the values.
 ; If one pushes a partial updated cache results in the publishing of the change
-; to /opencog_control topic thus resulting in an undesirable state in the
-; atomspace.
+; to /opencog_control/parameter_updates topic thus resulting in an undesirable
+; state in the atomspace.
 
 ; Update dynamic parameter cache
 (DefineLink

--- a/src/psi-behavior.scm
+++ b/src/psi-behavior.scm
@@ -132,6 +132,8 @@
 ;	speech-demand-satisfied (stv 1 1) speech-demand)
 
 
+; Any changes to the weight for controlled-psi-rules are pushed to ros
+; dynamic-parameters. Thus the web-ui mirrors the opencog wholeshow state.
 (psi-rule (list (DefinedPredicate "ROS is running?"))
 	(DefinedPredicate "update-web-ui")
 		update-demand-satisfied (stv 1 1) update-demand)

--- a/src/psi-behavior.scm
+++ b/src/psi-behavior.scm
@@ -131,7 +131,7 @@
 ;	(DefinedPredicate "Normal:amused")
 ;	speech-demand-satisfied (stv 1 1) speech-demand)
 
-;
-;(psi-rule (list (DefinedPredicate "ROS is running?"))
-;	(DefinedPredicate "update-web-ui")
-;		update-demand-satisfied (stv 1 1) update-demand)
+
+(psi-rule (list (DefinedPredicate "ROS is running?"))
+	(DefinedPredicate "update-web-ui")
+		update-demand-satisfied (stv 1 1) update-demand)

--- a/src/ros_commo.py
+++ b/src/ros_commo.py
@@ -283,14 +283,16 @@ class EvaControl():
 		param_name = name[len(psi_prefix) - 1:]
 
 		# Update parameter
-		if (param_name in self.param_dict):
-			# and (self.param_dict[param_name] != value):
+		if (param_name in self.param_dict) and \
+		   (self.param_dict[param_name] != value):
 			self.param_dict[param_name] = value
+			self.update_parameters = True
 
 
 	def push_parameter_update(self):
-		if not rospy.is_shutdown():
+		if self.update_parameters and not rospy.is_shutdown():
 			self.client.update_configuration(self.param_dict)
+			self.update_parameters = False
 
 
 	# ----------------------------------------------------------
@@ -451,6 +453,9 @@ class EvaControl():
 		# of the dictionary is only made from opencog side (openpsi
 		# updating rule)
 		self.param_dict = {}
+
+		# For controlling when to push updates, for saving bandwidth.
+		self.update_parameters = False
 
 		# For web ui based control of openpsi contorled-psi-rules
 		self.client = dynamic_reconfigure.client.Client("/opencog_control")


### PR DESCRIPTION
Any changes to the weight for controlled-psi-rules are pushed to ros dynamic-parameters. Thus the web-ui
mirrors opencog's wholeshow state.