### PR TITLE
Replace "emotion" -> "facial expression"

### DIFF
--- a/src/atomic-dbg.py
+++ b/src/atomic-dbg.py
@@ -126,15 +126,15 @@ def look_at_point(x_node, y_node, z_node):
 	# evl.look_at_point(x, y, z)
 	return TruthValue(1, 1)
 
-def do_emotion(emotion_node, duration_node, intensity_node):
-	emotion = emotion_node.name
+def do_face_expression(face_expression_node, duration_node, intensity_node):
+	face_expression = face_expression_node.name
 	duration = float(duration_node.name)
 	intensity = float(intensity_node.name)
-	print "(Eva expresses", emotion, "emotion for", duration, \
+	print "(Eva expresses", face_expression, "facial expression for", duration, \
 		 "seconds, with intensity", intensity, ")"
 
-	# print "Python emotion: ", emotion, " for ", duration, " int ", intensity
-	# evl.expression(emotion, intensity, duration)
+	# print "Python facial expression: ", face_expression, " for ", duration, " int ", intensity
+	# evl.expression(face_expression, intensity, duration)
 	return TruthValue(1, 1)
 
 def do_gesture(gesture_node, intensity_node, repeat_node, speed_node):

--- a/src/atomic.py
+++ b/src/atomic.py
@@ -85,12 +85,12 @@ def gaze_at_face_point(x, y, z):
 	evl.gaze_at_point(x, y, z)
 	return TruthValue(1, 1)
 
-def do_emotion(emotion_node, duration_node, intensity_node):
-	emotion = emotion_node.name
+def do_face_expression(face_expression_node, duration_node, intensity_node):
+	face_expression = face_expression_node.name
 	intensity = float(intensity_node.name)
 	duration = float(duration_node.name)
-	# print "Python emotion: ", emotion, " for ", duration, " int ", intensity
-	evl.expression(emotion, intensity, duration)
+	# print "Python facial expression: ", face_expression, " for ", duration, " int ", intensity
+	evl.expression(face_expression, intensity, duration)
 	return TruthValue(1, 1)
 
 def do_gesture(gesture_node, intensity_node, repeat_node, speed_node):

--- a/src/behavior.scm
+++ b/src/behavior.scm
@@ -177,7 +177,7 @@
 		; Record a new emotional state (for self-awareness)
 		; XXX FIXME this should be a prt of "Show random expression"
 		; below ...
-		(Put (DefinedPredicate "Request Set Emotion State")
+		(Put (DefinedPredicate "Request Set Face Expression")
 			(ListLink bhv-source (Concept "new-arrival")))
 
 		(DefinedPredicate "interact with new person")
@@ -408,7 +408,7 @@
 	(DefinedPredicateNode "Search for attention")
 	(SequentialAndLink
 		; Proceed only if we are allowed to.
-		(Put (DefinedPredicate "Request Set Emotion State")
+		(Put (DefinedPredicate "Request Set Face Expression")
 			(ListLink bhv-source (ConceptNode "bored")))
 
 		; If the room is empty, but we hear people talking ...
@@ -460,7 +460,7 @@
 	(DefinedPredicate "Go to sleep")
 	(SequentialAnd
 		; Proceed only if we are allowed to.
-		(Put (DefinedPredicate "Request Set Emotion State")
+		(Put (DefinedPredicate "Request Set Face Expression")
 			(ListLink bhv-source (ConceptNode "sleepy")))
 
 		; Proceed with the sleep animation only if the state
@@ -494,7 +494,7 @@
 			(ListLink bhv-source soma-awake))
 
 		; Proceed only if we are allowed to.
-		(Put (DefinedPredicate "Request Set Emotion State")
+		(Put (DefinedPredicate "Request Set Face Expression")
 			(ListLink bhv-source (ConceptNode "wake-up")))
 
 		(Evaluation (GroundedPredicate "scm: print-msg-time")

--- a/src/behavior.scm
+++ b/src/behavior.scm
@@ -100,6 +100,7 @@
 ; -- prior emotions when interacting with that face were positive
 ; -- prior emotions when interacting with that face were negative
 ; -- prior emotions when interacting with that face were neutral
+; We conflate "emotion" and "facial expression" here.
 ;
 ; 4) Introduction sequence
 ;    If the robot is talking to someone with whom it has not previously
@@ -175,7 +176,7 @@
 	(SequentialAnd
 		(DefinedPredicate "was room empty?")
 		; Record a new emotional state (for self-awareness)
-		; XXX FIXME this should be a prt of "Show random expression"
+		; XXX FIXME this should be a part of "Show random expression"
 		; below ...
 		(Put (DefinedPredicate "Request Set Face Expression")
 			(ListLink bhv-source (Concept "new-arrival")))

--- a/src/cfg-eva.scm
+++ b/src/cfg-eva.scm
@@ -11,7 +11,7 @@
 ;
 ; --------------------------------------------------------
 ; Emotional-state to expression mapping. For a given emotional state
-; (for example, happy, bored, excited) this specifies a range of
+; (for example, happy, bored, excited), this specifies a range of
 ; expressions to display for that emotional state, as well as the
 ; intensities and durations.
 
@@ -99,7 +99,7 @@
 
 ; --------------------------------------------------------
 ; Emotional-state to gesture mapping. For a given emotional state
-; (for example, happy, bored, excited) this specifies a range of
+; (for example, happy, bored, excited), this specifies a range of
 ; gestures to display for that emotional state, as well as the
 ; intensities and durations.
 ;

--- a/src/cfg-sophia.scm
+++ b/src/cfg-sophia.scm
@@ -11,7 +11,7 @@
 ;
 ; --------------------------------------------------------
 ; Emotional-state to expression mapping. For a given emotional state
-; (for example, happy, bored, excited) this specifies a range of
+; (for example, happy, bored, excited), this specifies a range of
 ; expressions to display for that emotional state, as well as the
 ; intensities and durations.
 ;
@@ -25,7 +25,8 @@
 ; * max duration of expression
 ;
 ; To view the available expressions, do this:
-; rostopic echo /blender_api/available_emotion_states
+;   `rostopic echo /blender_api/available_emotion_states`
+; You should see a response similar to the below:
 ; ['worry', 'happySurprise', 'happy.001', 'recoil', 'happyDisgust', 'happy',
 ; 'surprisedSad', 'surprised', 'sad', 'irritated', 'happy.002', 'fearSuprise',
 ; 'fear', 'engaged', 'disgustSurprise', 'disgust.Sad', 'disgust', 'contempt',
@@ -150,7 +151,7 @@
 
 ; --------------------------------------------------------
 ; Emotional-state to gesture mapping. For a given emotional state
-; (for example, happy, bored, excited) this specifies a range of
+; (for example, happy, bored, excited), this specifies a range of
 ; gestures to display for that emotional state, as well as the
 ; intensities and durations.
 ;

--- a/src/cfg-tools.scm
+++ b/src/cfg-tools.scm
@@ -8,7 +8,7 @@
 ;
 ; --------------------------------------------------------
 ; Emotional-state to expression mapping. For a given emotional state
-; (for example, happy, bored, excited) this specifies a range of
+; (for example, happy, bored, excited), this specifies a range of
 ; expressions to display for that emotional state, as well as the
 ; intensities and durations.  `emo-set` adds an expression to an
 ; emotional state, while `emo-map` is used to set parameters.
@@ -35,7 +35,7 @@
 
 ; --------------------------------------------------------
 ; Emotional-state to gesture mapping. For a given emotional state
-; (for example, happy, bored, excited) this specifies a range of
+; (for example, happy, bored, excited), this specifies a range of
 ; gestures to display for that emotional state, as well as the
 ; intensities and durations.  `ges-set` adds a gesture to an
 ; emotional state, while `ges-map` is used to set parameters.

--- a/src/express.scm
+++ b/src/express.scm
@@ -14,14 +14,16 @@
 ; (not implemented yet).
 ;
 ; --------------------------------------------------------
-; Given the name of a emotion, pick one of the allowed emotional
-; expressions at random. Example usage:
+; Given the name of an emotional-expression class, randomly pick one
+; of the facial expression animations in that class, at random.
+;
+; Example usage:
 ;
 ;   (cog-execute!
 ;      (PutLink (DefinedSchemaNode "Pick random expression")
 ;         (ConceptNode "positive")))
 ;
-; This will pick out one of the "positive" emotions (defined in the
+; This will pick out one of the "positive" expressions (defined in the
 ; previously-loaded `cfg-*.scm` file) and return it, as a `Concept`.
 ; For example: `(ConceptNode "comprehending")`
 ;
@@ -70,8 +72,8 @@
 				)))))
 
 ; Pick a random numeric value, lying in the range between min and max.
-; The range min and max depends on an emotion-expression pair. For an
-; example usage, see below.
+; The range min and max depends on a emotion-class+facial-expression
+; pair. For an example usage, see below.
 (define (pick-value-in-range min-name max-name)
 	(LambdaLink
 		(VariableList (VariableNode "$emo") (VariableNode "$expr"))
@@ -88,10 +90,10 @@
 					(SchemaNode max-name)) (VariableNode "$int-max")))
 		)))
 
-; Get a random intensity value for the indicated emotion-expression.
-; That is, given an emotion-expression pair, this wil look up the
-; min and max allowed intensity levels, and return a random number
-; betwee these min and max values.
+; Get a random intensity value for the indicated emotion-class +
+; facial-expression. That is, given an emotion-class+facial-expression
+; pair, this wil look up the min and max allowed intensity levels, and
+; return a random number between these min and max values.
 ;
 ; Example usage:
 ;    (cog-execute!
@@ -122,10 +124,10 @@
 	(DefinedSchemaNode "get random speed")
 	(pick-value-in-range "speed-min" "speed-max"))
 
-; Show an expression from a given emotional class. Sends the expression
-; to the action orchestrator for display.  The intensity and duration
-; of the expression is picked randomly from the configuration
-; parameters for the emotion-expression class.
+; Show a facial expression from a given emotional class. Sends the
+; expression to the action orchestrator for display.  The intensity
+; and duration of the expression is picked randomly from the configuration
+; parameters for the emotion class.
 ;
 ; Example usage:
 ;    (cog-evaluate!
@@ -149,9 +151,9 @@
 		))
 	))
 
-; Show a gesture for a given emotional class. Sends the gesture
-; to ROS for display.  The intensity, repetition and speed of the
-; gesture is picked randomly from the parameters for the emotion-gesture.
+; Show a gesture for a given emotional-expression class. Sends the
+; gesture to ROS for display.  The intensity, repetition and speed of the
+; gesture is picked randomly from the parameters for the facial-gesture.
 ;
 ; Example usage:
 ;    (cog-evaluate!
@@ -179,8 +181,8 @@
 	))
 
 ;
-; Pick an expression out of the given emotional class, and send it to
-; the action orchestrator for display.
+; Pick a facial expression out of the given emotional-expression class,
+; and send it to the action orchestrator for display.
 ; The expression is picked randomly from the class of expressions for
 ; the given emotion.  Likewise, the strength of display, and the
 ; duration are picked randomly.
@@ -190,7 +192,8 @@
 ;       (PutLink (DefinedPredicateNode "Show random expression")
 ;          (ConceptNode "positive")))
 ;
-; will pick one of the "positive" emotions, and send it off to ROS.
+; The above will pick one of the "positive" facial expressions, and
+; send it off to ROS.
 ;
 (DefineLink
 	(DefinedPredicateNode "Show random expression")
@@ -224,7 +227,7 @@
 ; --------------------------------------------------------
 ; Show facial expressions and gestures suitable for a given emotional
 ; state. These are random selectors, picking some expression randomly
-; from a meu of choices, ad displaying it.
+; from a menu of choices, and displaying it.
 
 ;; Pick random expression, and display it.
 (DefineLink

--- a/src/orchestrate.scm
+++ b/src/orchestrate.scm
@@ -125,7 +125,7 @@
 
 ; -------------------------------------------------------------
 ; As above, but (momentarily) break eye contact, first.
-; Otherwise, the behavior tree forces eye contact to be continueally
+; Otherwise, the behavior tree forces eye contact to be continually
 ; running, and the turn-look command is promptly over-ridden.
 ; XXX FIXME, this is still broken during search for attention.
 

--- a/src/orchestrate.scm
+++ b/src/orchestrate.scm
@@ -233,7 +233,7 @@
 			(List (Variable "sentence")))
 	))
 
-; Show happy emotion.
+; Show happy facial expression.
 ; XXX FIXME -- these have hard-coded length-of-time values in them.
 ; Most other similar behaviors have randomized values, which are
 ; controlled by bounds in the config files - cfg-sophia and cfg-eva.scm
@@ -244,7 +244,7 @@
         (List (Concept "happy") (NumberNode 3) (NumberNode 0.5))
     ))
 
-; Show amused emotion
+; Show amused facial expression
 (DefineLink
     (DefinedPredicate "Normal:amused")
     (Evaluation

--- a/src/orchestrate.scm
+++ b/src/orchestrate.scm
@@ -200,7 +200,7 @@
 ; request source or on other factors.
 
 (DefineLink
-	(DefinedPredicate "Request Set Emotion State")
+	(DefinedPredicate "Request Set Face Expression")
 	(LambdaLink
 		(VariableList
 			(Variable "$requestor")

--- a/src/orchestrate.scm
+++ b/src/orchestrate.scm
@@ -56,7 +56,7 @@
 			;; Record the time
 			(TrueLink (DefinedSchema "set expression timestamp"))
 			;; Send it off to ROS to actually do it.
-			(EvaluationLink (GroundedPredicate "py:do_emotion")
+			(EvaluationLink (GroundedPredicate "py:do_face_expression")
 				(ListLink
 					(Variable "$expr")
 					(Variable "$duration")
@@ -240,7 +240,7 @@
 (DefineLink
     (DefinedPredicate "Quiet:happy")
     (Evaluation
-        (GroundedPredicate "py: do_emotion")
+        (GroundedPredicate "py: do_face_expression")
         (List (Concept "happy") (NumberNode 3) (NumberNode 0.5))
     ))
 
@@ -248,7 +248,7 @@
 (DefineLink
     (DefinedPredicate "Normal:amused")
     (Evaluation
-        (GroundedPredicate "py: do_emotion")
+        (GroundedPredicate "py: do_face_expression")
         (List (Concept "amused") (NumberNode 3) (NumberNode 0.5))
     ))
 

--- a/src/orchestrate.scm
+++ b/src/orchestrate.scm
@@ -190,7 +190,7 @@
 	))
 
 ; -------------------------------------------------------------
-; Request to change the emotion state.
+; Request to change the facial expression state.
 ; Takes two arguments: the requestor, and the proposed state.
 ;
 ; Currently, this always honors all requests.
@@ -205,7 +205,7 @@
 		(VariableList
 			(Variable "$requestor")
 			(Variable "$state"))
-		(True (State emotion-state (Variable "$state")))
+		(True (State face-expression-state (Variable "$state")))
 	))
 
 ; -------------------------------------------------------------

--- a/src/ros_commo.py
+++ b/src/ros_commo.py
@@ -105,7 +105,7 @@ class EvaControl():
 		self.soma_state('normal', 0.1, 1, 3)
 
 	# ----------------------------------------------------------
-	# Wrapper for emotional expressions
+	# Wrapper for facial expressions
 	def expression(self, name, intensity, duration):
 		if 'noop' == name or (not self.control_mode & self.C_EXPRESSION):
 			return
@@ -115,8 +115,8 @@ class EvaControl():
 		exp.magnitude = intensity
 		exp.duration.secs = int(duration)
 		exp.duration.nsecs = 1000000000 * (duration - int(duration))
-		self.emotion_pub.publish(exp)
-		print "Publish expression:", exp.name
+		self.expression_pub.publish(exp)
+		print "Publish facial expression:", exp.name
 
 	# Wrapper for Soma state expressions
 	def soma_state(self, name, intensity, rate, ease_in=0.0):
@@ -303,9 +303,9 @@ class EvaControl():
 	def get_gestures_cb(self, msg):
 		print("Available Gestures:" + str(msg.data))
 
-	# Get the list of available emotional expressions.
-	def get_emotion_states_cb(self, msg):
-		print("Available Emotion States:" + str(msg.data))
+	# Get the list of available facial expressions.
+	def get_expressions_cb(self, msg):
+		print("Available Facial Expressions:" + str(msg.data))
 
 	# ----------------------------------------------------------
 
@@ -466,15 +466,15 @@ class EvaControl():
 			self.client = None
 
 		# ----------------
-		# Get the available animations
+		# Get the available facial animations
 		rospy.Subscriber("/blender_api/available_emotion_states",
-		       AvailableEmotionStates, self.get_emotion_states_cb)
+		       AvailableEmotionStates, self.get_expressions_cb)
 
 		rospy.Subscriber("/blender_api/available_gestures",
 		       AvailableGestures, self.get_gestures_cb)
 
 		# Send out facial expressions and gestures.
-		self.emotion_pub = rospy.Publisher("/blender_api/set_emotion_state",
+		self.expression_pub = rospy.Publisher("/blender_api/set_emotion_state",
 		                                   EmotionState, queue_size=1)
 		self.gesture_pub = rospy.Publisher("/blender_api/set_gesture",
 		                                   SetGesture, queue_size=1)

--- a/src/self-model.scm
+++ b/src/self-model.scm
@@ -103,8 +103,11 @@
 			(State soma-state (Variable "$x")))))
 
 ; -----------
-; The "emotional state" of the robot.  Corresponds to states declared
-; in the `cfg-*.scm` file.
+; The facial expression state of the robot.  The set of possible values
+; correspond to states declared in the `cfg-*.scm` file.  The facial
+; expression state records what the robot is currently doing, so that
+; questions such as "what are you doing?" get answered correctly:
+; e.g. "I am smiling", etc.
 ;
 ; See the README-affects.md for general discussion.
 (define-public face-expression-state (AnchorNode "Facial Expression State"))
@@ -149,9 +152,10 @@
 
 ; --------------------------------------------------------
 ; Chatbot-related stuff.  In the current design, the chatbot talks
-; whenever it feels like it; we are simply told when it is talking
-; when it has stopped talking, and what emotions we should display,
-; so that it's consistent with the speech emotions.
+; whenever it feels like it; we are simply told when it is talking,
+; when it has stopped talking, and what facial expressions we should
+; display, so that it's consistent with the emotional content of what
+; is being said.
 
 ; Chat state. Is the robot talking (vocalizing), or not, right now?
 ; NB the python code in put_atoms.py uses these defines!

--- a/src/self-model.scm
+++ b/src/self-model.scm
@@ -583,7 +583,7 @@
 
 (define-public (get-face-id face-concept)
 "
-  For casting ConceptNode to NumberNode
+  get-face-id FACE-CONCEPT - Cast ConceptNode to NumberNode
 "
 	(NumberNode (cog-name face-concept))
 )

--- a/src/self-model.scm
+++ b/src/self-model.scm
@@ -106,12 +106,11 @@
 ; The "emotional state" of the robot.  Corresponds to states declared
 ; in the `cfg-*.scm` file.
 ;
-; XXX this should be renamed "current facial expression", see the
-; README-affects.md for general discussion.
-(define-public emotion-state (AnchorNode "Emotion State"))
-(define-public emotion-neutral (ConceptNode "neutral"))
+; See the README-affects.md for general discussion.
+(define-public face-expression-state (AnchorNode "Facial Expression State"))
+(define-public expression-neutral (ConceptNode "neutral"))
 
-(StateLink emotion-state emotion-neutral)
+(StateLink face-expression-state expression-neutral)
 
 ; -----------
 ;; The eye-contact-state will be linked to the face-id of


### PR DESCRIPTION
Many things called "emotion" in the code base really meant "facial expression".  To avoid confusion with the use of the word "emotion" in open-psi, this pull req simply renames many uses of "emotion" to "facial expression". This should make psi integration simpler to understand.

There are no functional changes in this code.