### PR TITLE
Work around a hang.

### DIFF
--- a/src/put_atoms.py
+++ b/src/put_atoms.py
@@ -93,7 +93,11 @@ class PutAtoms:
 
 	def wholeshow_start(self):
 		scheme_eval(self.atomspace, "(enable-all-demos)")
-		scheme_eval(self.atomspace, "(run)")
+		# pipe stdout to /dev/null, as otherwise the the stdout pipe
+		# attached to the evaluator will fill up with messages, (which
+		# no one, i.e. python, ever fetches) and then stall.
+		scheme_eval(self.atomspace, \
+			'(set-current-output-port (%make-void-port "w"))(run)')
 
 	# Generic function for experimentation and with use with different robots
 	# or game-worlds like minecraft.


### PR DESCRIPTION
This should cure the hang that was seen shortly before the demo.  The issue, not documented anywhere on github, but discussed in detail in person and in emails, is due to the fact that a pipe fills up with print messages from stdout, and then stalls. Since there is no python code to drain that pipe, and the pipe is of finite size, the stall is inevitable, as long as some, any psi-rule performs any kind of printing.

The solution here is to simply pipe all of the output to /dev/null.  This only affects the current scheme command, and anything run in it's environment, and nothing else.
