### PR TITLE
Use 'SentenceNode' instead of just 'Sentence'

### DIFF
--- a/src/time-map.scm
+++ b/src/time-map.scm
@@ -186,7 +186,7 @@
 				(PredicateNode "say_face")
 					(ListLink
 						(Concept (cog-name (VariableNode "$fid")))
-						(Sentence sent)))
+						(SentenceNode sent)))
 				(Concept "sound-perception"))
 			(Get (State last-speaker (Variable "$fid")))
 		))


### PR DESCRIPTION
To avoid getting the "expecting opencog atom" error as there are `SentenceLink` and `SentenceNode` and by default it's assumed to be a link