### PR TITLE
Fix the issue that is causing the chatbot to reply twice

### DIFF
--- a/src/face-priority.scm
+++ b/src/face-priority.scm
@@ -1,9 +1,6 @@
 (use-modules (opencog))
 (use-modules (ice-9 threads))
-
-(load "time-map.scm")
-(load "self-model.scm")
-(load "primitives.scm")
+(use-modules (opencog eva-model) (opencog eva-behavior))
 
 ; -----------------------------------------------------------------------------
 ; TODO: Make the set, get, & delete of properites into a utility template

--- a/src/faces.scm
+++ b/src/faces.scm
@@ -130,7 +130,7 @@
 	(map (lambda (x) (car (cog-outgoing-set x)))
 	(cog-chase-link 'EvaluationLink 'ListLink visible-face))))
 
-(define (show-acked-faces)
+(define-public (show-acked-faces)
 	(define acked-face (PredicateNode "acked face"))
 	(filter (lambda(y) (equal? (cog-type y) 'NumberNode))
 	(map (lambda (x) (car (cog-outgoing-set x)))

--- a/src/time-map.scm
+++ b/src/time-map.scm
@@ -56,7 +56,7 @@
 ;;
 ;; This function assumes that an atom can have only one location at a
 ;; time.
-(define (get-last-xyz map-name id-node elapse)
+(define-public (get-last-xyz map-name id-node elapse)
 	;
 	; get-last-locs-ato returns a SetLink holding AtLocationLinks
 	; of the form below:


### PR DESCRIPTION
It turns out that there are actually two instances of the same subscriber (or more precisely two instances of EvaControl) subscribing to the same "chatbot_speech" ROS topic (and many other topics too), so whenever a message arrives it will send two identical messages to the cogserver.

The additional instance is created by manually loading `primitives.scm`, which will load `atomic.py` and as a result create an instance of EvaControl. That probably also means that many of the messages (handle by the publishers and subscribers defined in EvaControl) have actually been processed and evaluated in the cogserver twice.