### PR TITLE
Simplify the saliency tracking rule

### DIFF
--- a/src/orchestrate.scm
+++ b/src/orchestrate.scm
@@ -262,21 +262,21 @@
 
 ;Salient
 (DefineLink
-    (DefinedPredicate "look at salient point")
-		(SequentialAnd
-    (True (Put (Evaluation
-        (DefinedPredicate "Look at point")
-        (ListLink (Variable "$x") (Variable "$y") (Variable "$z")))
-            (Get (State salient-loc
-            (ListLink (Variable "$x") (Variable "$y") (Variable "$z"))))
-        ))
-		(True (Put (Evaluation
-        (DefinedPredicate "Gaze at point")
-        (ListLink (Variable "$x") (Variable "$y") (Variable "$z")))
-            (Get (State salient-loc
-            (ListLink (Variable "$x") (Variable "$y") (Variable "$z"))))
-        ))
+	(DefinedPredicate "look at salient point")
+	(SequentialAnd
+		(True (Put
+			(Evaluation (DefinedPredicate "Look at point")
+				(List (Variable "$x") (Variable "$y") (Variable "$z")))
+			(Get (State salient-loc
+				(List (Variable "$x") (Variable "$y") (Variable "$z"))))
 		))
+		(True (Put
+			(Evaluation (DefinedPredicate "Gaze at point")
+				(List (Variable "$x") (Variable "$y") (Variable "$z")))
+			(Get (State salient-loc
+				(List (Variable "$x") (Variable "$y") (Variable "$z"))))
+		))
+	))
 
 
 ; -------------------------------------------------------------

--- a/src/psi-behavior.scm
+++ b/src/psi-behavior.scm
@@ -23,6 +23,10 @@
 (define track-demand (psi-demand "track demand" 1))
 (define track-demand-satisfied (True))
 
+; Demand for saliency tracking
+(define salient-demand (psi-demand "salient demand" 1))
+(define salient-demand-satisfied (True))
+
 ; Demand for contorl with web-ui
 (define update-demand (psi-demand "update demand" 1))
 (define update-demand-satisfied (True))
@@ -161,14 +165,14 @@
 ;; saliency
 (psi-set-controlled-rule
 	(psi-rule (list (True))
-			(DefinedPredicate "Salient:Curious")
-			(True) (stv 0.9 0.9) face-demand "saliency-tracking")
+		(DefinedPredicate "Salient:Curious")
+		salient-demand-satisfied (stv 1 1) salient-demand "saliency-tracking")
 )
 ;; stop tracking
 (psi-set-controlled-rule
 	(psi-rule (list (True))
-			(DefinedPredicate "salient-flag-off")
-			(True) (stv 0.9 0.9) face-demand "not-saliency-tracking")
+		(DefinedPredicate "salient-flag-off")
+		salient-demand-satisfied (stv 1 1) salient-demand "not-saliency-tracking")
 )
 
 (psi-rule (list (DefinedPredicate "Room bright?"))

--- a/src/psi-behavior.scm
+++ b/src/psi-behavior.scm
@@ -31,27 +31,6 @@
 (define update-demand (psi-demand "update demand" 1))
 (define update-demand-satisfied (True))
 
-(define saliency-tracking (Anchor "SaliencyTracking"))
-(define is-tracking (Concept "IsTracking"))
-(define not-tracking (Concept "NotTracking"))
-(State saliency-tracking not-tracking)
-
-(DefineLink
-	(DefinedPredicate "tracking-salient?")
-	(Equal is-tracking
-		(Get (State saliency-tracking (Variable "$x")))
-	))
-
-(DefineLink
-	(DefinedPredicate "salient-flag-off")
-	(True (Put (State saliency-tracking (Variable "$x")) not-tracking))
-)
-
-(DefineLink
-	(DefinedPredicate "salient-flag-on")
-	(True (Put (State saliency-tracking (Variable "$x")) is-tracking))
-)
-
 (DefineLink
 	(DefinedPredicate "Nothing happening?")
 	(NotLink
@@ -75,11 +54,7 @@
 	face-demand-satisfied (stv 1 1) face-demand)
 
 
-(psi-rule (list
-		(SequentialAnd
-		(NotLink (DefinedPredicate "tracking-salient?"))
-		(DefinedPredicate "Someone requests interaction?"))
-	)
+(psi-rule (list (DefinedPredicate "Someone requests interaction?"))
 	(DefinedPredicate "Interaction requested action")
 	face-demand-satisfied (stv 1 1) face-demand)
 
@@ -93,23 +68,21 @@
 
 ; This rule is the old multiple-face tracking rule
 ; TODO Remove after thoroughly testing behavior on robot.
-(psi-rule (list (SequentialAnd (NotLink (DefinedPredicate "Skip Interaction?"))
-		(NotLink (DefinedPredicate "tracking-salient?"))
+(psi-rule (list (SequentialAnd
+		(NotLink (DefinedPredicate "Skip Interaction?"))
 		(DefinedPredicate "Someone visible?")))
 	(DefinedPredicate "Interact with people")
 	face-demand-satisfied (stv 1 1) face-demand)
 
 ; TODO: How should rules that could run concurrently be represented, when
 ; we have action compostion(aka Planning/Orchestration)?
-(psi-rule (list (SequentialAnd (DefinedPredicate "Someone visible?")
-	(NotLink (DefinedPredicate "tracking-salient?"))))
+(psi-rule (list (DefinedPredicate "Someone visible?"))
 	(DefinedPredicate "Interact with face")
 	track-demand-satisfied (stv .5 .5) track-demand)
 
 (psi-rule (list (SequentialAnd
 		; TODO: test the behabior when talking.
 		; (Not (DefinedPredicate "chatbot is talking?"))
-		(NotLink (DefinedPredicate "tracking-salient?"))
 		(DefinedPredicate "Someone visible?")
 		(DefinedPredicate "Time to change interaction")))
 	(DefinedPredicate "Change interaction target by priority")
@@ -168,12 +141,6 @@
 	(psi-rule (list (True))
 		(DefinedPredicate "Salient:Curious")
 		salient-demand-satisfied (stv 1 1) salient-demand "saliency-tracking"))
-
-;; stop saliency tracking
-;; XXX Who is calling this?
-(psi-rule (list (True))
-	(DefinedPredicate "salient-flag-off")
-	salient-demand-satisfied (stv 1 1) salient-demand)
 
 (psi-rule (list (DefinedPredicate "Room bright?"))
 	(DefinedPredicate "Bright:happy")

--- a/src/psi-behavior.scm
+++ b/src/psi-behavior.scm
@@ -163,18 +163,17 @@
 	(DefinedPredicate "Say whoa!")
 	speech-demand-satisfied (stv 1 1) speech-demand)
 
-;; saliency
+;; saliency tracking
 (psi-set-controlled-rule
 	(psi-rule (list (True))
 		(DefinedPredicate "Salient:Curious")
-		salient-demand-satisfied (stv 1 1) salient-demand "saliency-tracking")
-)
-;; stop tracking
-(psi-set-controlled-rule
-	(psi-rule (list (True))
-		(DefinedPredicate "salient-flag-off")
-		salient-demand-satisfied (stv 1 1) salient-demand "not-saliency-tracking")
-)
+		salient-demand-satisfied (stv 1 1) salient-demand "saliency-tracking"))
+
+;; stop saliency tracking
+;; XXX Who is calling this?
+(psi-rule (list (True))
+	(DefinedPredicate "salient-flag-off")
+	salient-demand-satisfied (stv 1 1) salient-demand)
 
 (psi-rule (list (DefinedPredicate "Room bright?"))
 	(DefinedPredicate "Bright:happy")

--- a/src/psi-behavior.scm
+++ b/src/psi-behavior.scm
@@ -31,24 +31,25 @@
 (define update-demand (psi-demand "update demand" 1))
 (define update-demand-satisfied (True))
 
-(State (ConceptNode "saliency-tracking") (NumberNode "0"))
+(define saliency-tracking (Anchor "SaliencyTracking"))
+(define is-tracking (Concept "IsTracking"))
+(define not-tracking (Concept "NotTracking"))
+(State saliency-tracking not-tracking)
 
 (DefineLink
 	(DefinedPredicate "tracking-salient?")
-	(GreaterThan
-		(Get (State (ConceptNode "saliency-tracking")(VariableNode "$x")))
-		(NumberNode "0.5")))
+	(Equal is-tracking
+		(Get (State saliency-tracking (Variable "$x")))
+	))
 
 (DefineLink
 	(DefinedPredicate "salient-flag-off")
-  (True
-		(Put (State (ConceptNode "saliency-tracking")(Variable "$x")) (NumberNode "0")))
+	(True (Put (State saliency-tracking (Variable "$x")) not-tracking))
 )
 
 (DefineLink
 	(DefinedPredicate "salient-flag-on")
-  (True
-		(Put (State (ConceptNode "saliency-tracking")(Variable "$x")) (NumberNode "1.0")))
+	(True (Put (State saliency-tracking (Variable "$x")) is-tracking))
 )
 
 (DefineLink


### PR DESCRIPTION
Simplify the implementation, and this seems to fix https://github.com/opencog/ros-behavior-scripting/issues/155 as well. The next step is to better integrate saliency tracking with face tracking and other existing rules.