### PR TITLE
Fix the DefinedPredicate "Look-at-thing cmd"

### DIFF
--- a/src/orchestrate.scm
+++ b/src/orchestrate.scm
@@ -168,9 +168,7 @@
 		(SequentialOr
 			(SequentialAnd
 				(Equal (Variable "$object-id") (Concept "salient-point"))
-				(Evaluation
-					(DefinedPredicate "look at salient point")
-					(ListLink (Variable "$object-id"))))
+				(DefinedPredicate "look at salient point"))
 			(Evaluation
 				(DefinedPredicate "Set interaction target")
 				(ListLink (Variable "$object-id")))


### PR DESCRIPTION
It's giving an `Expecting definition to be a LambdaLink, got ...` exception when doing
```
(Evaluation
    (DefinedPredicate "look at salient point")
    (ListLink (Variable "$object-id"))))
```

Since `(DefinedPredicate "look at salient point")` knows where to get the salient points anyway, we can call it directly.