### PR TITLE
Increase the 'waitForTransform' duration

### DIFF
--- a/src/ros_commo.py
+++ b/src/ros_commo.py
@@ -461,7 +461,7 @@ class EvaControl():
 		print "**1\n"
 		try:
 			self.tf_listener.waitForTransform('camera', self.LOCATION_FRAME, \
-				rospy.Time(0), rospy.Duration(3.0))#world
+				rospy.Time(0), rospy.Duration(10.0))#world
 			print "***2\n"
 		except Exception:
 			print("No camera transforms!\n")


### PR DESCRIPTION
It throws the "No camera transforms!" exception quite often especially when I'm running the whole stack on two computers, turns out that it just need some more time here